### PR TITLE
OUT-74 Fallback image logic

### DIFF
--- a/src/app/client-preview/page.tsx
+++ b/src/app/client-preview/page.tsx
@@ -82,7 +82,11 @@ export default async function ClientPreviewPage({
       {settings?.bannerImage?.url && (
         <img
           className='w-full object-fill xl:object-cover'
-          src={settings?.bannerImage?.url || '/images/default_banner.png'}
+          src={
+            !_settings
+              ? '/images/default_banner.png'
+              : settings?.bannerImage.url
+          }
           alt='banner image'
           style={{
             height: '25vh',

--- a/src/app/components/EditorInterface.tsx
+++ b/src/app/components/EditorInterface.tsx
@@ -346,7 +346,7 @@ const EditorInterface = ({ settings, token }: IEditorInterface) => {
                   right: 10,
                   display: bannerImageHovered ? 'block' : 'none',
                   cursor: 'pointer',
-                  color: '#000',
+                  color: '#fff',
                 }}
                 onClick={() => {
                   appState?.setBannerImgId('')


### PR DESCRIPTION
### Task/Ticket

[Fallback image is not shown in client portal](https://linear.app/copilotplatforms/issue/OUT-74/fallback-image-is-not-shown-in-client-portal)

#### The main changes are

- [x] Uploads fallback image if no image is uploaded on the first save
- [x] Handles fallback image on the client-preview route
