### PR TITLE
fix: portalName is no longer part of this payload

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -5,7 +5,6 @@ export const MeResponseSchema = z.object({
   givenName: z.string(),
   familyName: z.string(),
   email: z.string(),
-  portalName: z.string(),
 })
 export type MeResponse = z.infer<typeof MeResponseSchema>
 


### PR DESCRIPTION
This PR removes portalName from the MeResponseSchema object. That property was removed from the response. It also seems like it's never used in client home, so we can safely delete this line.