### PR TITLE
OUT-109 Banner image gets reset on first save

### DIFF
--- a/src/app/client-preview/page.tsx
+++ b/src/app/client-preview/page.tsx
@@ -2,6 +2,7 @@ import Handlebars from 'handlebars'
 import { IClient, ISettings } from '@/types/interfaces'
 import ClientPreview from '../components/ClientPreview'
 import { apiUrl } from '@/config'
+import { defaultBannerImagePath } from '@/utils/constants'
 
 export const revalidate = 0
 
@@ -82,11 +83,7 @@ export default async function ClientPreviewPage({
       {settings?.bannerImage?.url && (
         <img
           className='w-full object-fill xl:object-cover'
-          src={
-            !_settings
-              ? '/images/default_banner.png'
-              : settings?.bannerImage.url
-          }
+          src={!_settings ? defaultBannerImagePath : settings?.bannerImage.url}
           alt='banner image'
           style={{
             height: '25vh',

--- a/src/app/components/EditorInterface.tsx
+++ b/src/app/components/EditorInterface.tsx
@@ -188,7 +188,8 @@ const EditorInterface = ({ settings, token }: IEditorInterface) => {
     if (editor && appState?.appState.settings?.content.includes(defaultState)) {
       if (
         appState?.appState.originalTemplate?.replace(/\s/g, '') !==
-        defaultState.replace(/\s/g, '')
+          defaultState.replace(/\s/g, '') ||
+        appState?.appState.bannerImgUrl !== '/images/default_banner.png'
       ) {
         appState?.toggleChangesCreated(true)
       } else {

--- a/src/app/components/EditorInterface.tsx
+++ b/src/app/components/EditorInterface.tsx
@@ -49,6 +49,7 @@ import { defaultState } from '../../../defaultState'
 import Image from 'next/image'
 import { Box } from '@mui/material'
 import { Delete } from '@mui/icons-material'
+import { defaultBannerImagePath } from '@/utils/constants'
 
 interface IEditorInterface {
   settings: ISettings | null
@@ -189,7 +190,7 @@ const EditorInterface = ({ settings, token }: IEditorInterface) => {
       if (
         appState?.appState.originalTemplate?.replace(/\s/g, '') !==
           defaultState.replace(/\s/g, '') ||
-        appState?.appState.bannerImgUrl !== '/images/default_banner.png'
+        appState?.appState.bannerImgUrl !== defaultBannerImagePath
       ) {
         appState?.toggleChangesCreated(true)
       } else {
@@ -255,7 +256,7 @@ const EditorInterface = ({ settings, token }: IEditorInterface) => {
           id: '',
           bannerImage: {
             id: '',
-            url: '/images/default_banner.png',
+            url: defaultBannerImagePath,
             filename: '',
             contentType: '',
             size: 0,

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -2,6 +2,7 @@
 
 import { When } from '@/components/hoc/When'
 import { useAppState } from '@/hooks/useAppState'
+import { defaultBannerImagePath } from '@/utils/constants'
 import { handleBannerImageUpload } from '@/utils/handleBannerImageUpload'
 import { ImagePickerUtils } from '@/utils/imagePickerUtils'
 import { useEffect } from 'react'
@@ -38,9 +39,9 @@ export const Footer = () => {
 
     let payload = {}
 
-    if (appState?.appState?.bannerImgUrl === '/images/default_banner.png') {
+    if (appState?.appState?.bannerImgUrl === defaultBannerImagePath) {
       const imagePickerUtils = new ImagePickerUtils()
-      const imageResponse = await fetch(`/images/default_banner.png`)
+      const imageResponse = await fetch(defaultBannerImagePath)
       const imageBlob = await imageResponse.blob()
       const imageFile = await imagePickerUtils.blobToFile(
         imageBlob,

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { When } from '@/components/hoc/When'
-import { apiUrl } from '@/config'
 import { useAppState } from '@/hooks/useAppState'
 import { handleBannerImageUpload } from '@/utils/handleBannerImageUpload'
 import { ImagePickerUtils } from '@/utils/imagePickerUtils'
@@ -39,10 +38,7 @@ export const Footer = () => {
 
     let payload = {}
 
-    if (
-      appState?.appState?.settings?.bannerImage?.url ===
-      '/images/default_banner.png'
-    ) {
+    if (appState?.appState?.bannerImgUrl === '/images/default_banner.png') {
       const imagePickerUtils = new ImagePickerUtils()
       const imageResponse = await fetch(`/images/default_banner.png`)
       const imageBlob = await imageResponse.blob()

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -4,3 +4,5 @@ export const staticAutofillValues = [
   '{{client.email}}',
   '{{client.company}}',
 ]
+
+export const defaultBannerImagePath = '/images/default_banner.png'


### PR DESCRIPTION
### Task/Ticket

[Banner image gets reset on first save](https://linear.app/copilotplatforms/issue/OUT-109/banner-image-gets-reset-on-first-save)

#### The main changes are

- [x] Fixes banner images getting reset on first save