### PR TITLE
OUT-135 Client Home crashing when client.company turns into a link

### DIFF
--- a/src/app/components/EditorInterface.tsx
+++ b/src/app/components/EditorInterface.tsx
@@ -96,6 +96,8 @@ const EditorInterface = ({ settings, token }: IEditorInterface) => {
       }),
       Link.extend({
         exitable: true,
+      }).configure({
+        autolink: false,
       }),
       OrderedList.configure({
         itemTypeName: 'listItem',


### PR DESCRIPTION
### Task/Ticket

[Client Home crashing when client.company turns into a link](https://linear.app/copilotplatforms/issue/OUT-135/client-home-crashing-when-clientcompany-turns-into-a-link)

#### The main changes are

- [x] Disabled autolink 
