### PR TITLE
OUT-128 Include all autofill fields of the client in sidebar, even if empty

### DIFF
--- a/src/components/autofillFields/AutofillFields.tsx
+++ b/src/components/autofillFields/AutofillFields.tsx
@@ -1,17 +1,28 @@
 import { useAppState } from '@/hooks/useAppState'
-import { IClient } from '@/types/interfaces'
+import { IClient, ICustomField } from '@/types/interfaces'
 import { staticAutofillValues } from '@/utils/constants'
 import { TiptapEditorUtils } from '@/utils/tiptapEditorUtils'
 import { Editor } from '@tiptap/react'
 import { When } from '../hoc/When'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 const AutofillFields = () => {
   const appState = useAppState()
 
+  const [remainingAutofill, setRemainingAutofill] = useState<ICustomField[]>([])
+
   const tiptapEditorUtils = new TiptapEditorUtils(
     appState?.appState.editor as Editor,
   )
+
+  function getRemainingAutofillFields(
+    customFields: ICustomField[],
+    clientCustomField: any,
+  ) {
+    return customFields.filter(
+      (itemA: any) => !Object.keys(clientCustomField).includes(itemA.key),
+    )
+  }
 
   useEffect(() => {
     if (!appState?.appState?.selectedClient && !appState?.appState?.readOnly)
@@ -19,6 +30,11 @@ const AutofillFields = () => {
     appState?.setClientCompanyName('')
     ;(async () => {
       appState?.setLoading(true)
+      const output = getRemainingAutofillFields(
+        appState?.appState.customFields,
+        appState?.appState.selectedClient?.customFields,
+      )
+      setRemainingAutofill(output)
       const res = await fetch(
         `/api/companies?companyId=${appState?.appState.selectedClient?.companyId}&token=${appState?.appState?.token}`,
       )
@@ -74,6 +90,16 @@ const AutofillFields = () => {
                   key={key}
                   labelName={value[0]}
                   labelValues={value[1]}
+                />
+              )
+            })}
+          {appState?.appState?.selectedClient &&
+            remainingAutofill.map((el, key) => {
+              return (
+                <AutofillTextStaticField
+                  key={key}
+                  labelName={el.name}
+                  labelValues={''}
                 />
               )
             })}


### PR DESCRIPTION
### Task/Ticket

[Include all autofill fields of the client in sidebar, even if empty](https://linear.app/copilotplatforms/issue/OUT-128/include-all-autofill-fields-of-the-client-in-sidebar-even-if-empty)

#### The main changes are

- [x] Adds all autofield fields in readmode in the sidebar even though they are empty
