### PR TITLE
Out 202 207 Banner image issue and autofill issue

### DIFF
--- a/src/app/client-preview/page.tsx
+++ b/src/app/client-preview/page.tsx
@@ -125,8 +125,6 @@ export default async function ClientPreviewPage({
     ? '/images/default_banner.png'
     : settings?.bannerImage?.url
 
-  console.log(defaultSetting)
-
   return (
     <div
       className={`overflow-y-auto overflow-x-hidden max-h-screen w-full`}

--- a/src/app/client-preview/page.tsx
+++ b/src/app/client-preview/page.tsx
@@ -125,6 +125,8 @@ export default async function ClientPreviewPage({
     ? '/images/default_banner.png'
     : settings?.bannerImage?.url
 
+  console.log(defaultSetting)
+
   return (
     <div
       className={`overflow-y-auto overflow-x-hidden max-h-screen w-full`}
@@ -132,23 +134,21 @@ export default async function ClientPreviewPage({
         background: `${settings.backgroundColor}`,
       }}
     >
-      <Image
-        className='w-full'
-        src={
-          settings.bannerImage?.url
-            ? (bannerImgUrl as string)
-            : '/images/default_banner.png'
-        }
-        alt='banner image'
-        width={0}
-        height={0}
-        sizes='100vw'
-        style={{
-          width: '100%',
-          height: '25vh',
-          objectFit: 'cover',
-        }}
-      />
+      {bannerImgUrl && (
+        <Image
+          className='w-full'
+          src={bannerImgUrl}
+          alt='banner image'
+          width={0}
+          height={0}
+          sizes='100vw'
+          style={{
+            width: '100%',
+            height: '25vh',
+            objectFit: 'cover',
+          }}
+        />
+      )}
       <div
         className='px-14 py-350 max-w-xl'
         style={{

--- a/src/app/components/ClientPreview.tsx
+++ b/src/app/components/ClientPreview.tsx
@@ -125,7 +125,7 @@ const ClientPreview = ({
         id: '',
         bannerImage: {
           id: '',
-          url: defaultBannerImagePath,
+          url: '',
           filename: '',
           contentType: '',
           size: 0,

--- a/src/app/components/EditorInterface.tsx
+++ b/src/app/components/EditorInterface.tsx
@@ -190,6 +190,7 @@ const EditorInterface = ({ settings, token }: IEditorInterface) => {
   }, [
     appState?.appState.selectedClient,
     appState?.appState.selectedClientCompanyName,
+    appState?.appState.notifications,
   ])
 
   useEffect(() => {


### PR DESCRIPTION
Ref: https://linear.app/copilotplatforms/issue/OUT-202/default-banner-image-shows-up-to-clients-when-banner-image-is-empty
Ref: https://linear.app/copilotplatforms/issue/OUT-207/switching-in-and-out-of-preview-causes-issues-with-autofill-fields

- Fixes issue for default banner image showing in client preview even though image is not set by IU
- Fixes autofill field issue
