### PR TITLE
OUT 220 A few lines in the right sidebar are white instead of black when the notifications widget is open

### DIFF
--- a/src/components/NotificationsModal/index.tsx
+++ b/src/components/NotificationsModal/index.tsx
@@ -117,6 +117,7 @@ const NotificationsModal = ({ settings }: NotificationsModalProps) => {
           timeout: 250,
         },
       }}
+      sx={{ zIndex: 999999999 }} //highest in the app
     >
       <div className='absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-[80vw] max-w-[720px] bg-white rounded-md shadow-lg outline-none font-medium'>
         <Fade in={showError}>


### PR DESCRIPTION
Ref: https://linear.app/copilotplatforms/issue/OUT-220/a-few-lines-in-the-right-sidebar-are-white-instead-of-black-when-the

- Fixes appearing of unwanted lines when the notification widget modal is open 
