### PR TITLE
OUT-353 Show error message when banner image file size exceeds 4.5MB limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "react-dom": "latest",
     "react-dropzone": "^14.2.3",
     "react-easy-crop": "^5.0.2",
+    "react-hot-toast": "^2.4.1",
     "swr": "^2.2.5",
     "zod": "^3.22.4"
   },

--- a/src/app/components/EditorInterface.tsx
+++ b/src/app/components/EditorInterface.tsx
@@ -3,6 +3,7 @@
 import { useEditor, EditorContent } from '@tiptap/react'
 import { useEffect, useState } from 'react'
 
+import { Toaster } from 'react-hot-toast'
 import Handlebars from 'handlebars'
 import { Scrollbars } from 'react-custom-scrollbars'
 import CalloutExtension from '@/components/tiptap/callout/CalloutExtension'
@@ -337,6 +338,7 @@ const EditorInterface = ({ settings, token }: IEditorInterface) => {
 
   return (
     <>
+      <Toaster position='top-center' toastOptions={{ duration: 5000 }} />
       <When condition={appState?.appState.loading as boolean}>
         <LoaderComponent />
       </When>

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -2,10 +2,12 @@
 
 import { When } from '@/components/hoc/When'
 import { useAppState } from '@/hooks/useAppState'
+import { calculateFileSize } from '@/utils/calculateFileSize'
 import { defaultBannerImagePath } from '@/utils/constants'
 import { handleBannerImageUpload } from '@/utils/handleBannerImageUpload'
 import { ImagePickerUtils } from '@/utils/imagePickerUtils'
 import { useEffect, useState } from 'react'
+import toast from 'react-hot-toast'
 
 export const Footer = () => {
   const appState = useAppState()
@@ -49,6 +51,14 @@ export const Footer = () => {
         imageBlob,
         'bannerImg',
       )
+      if (imageFile) {
+        const size = calculateFileSize(imageFile)
+        if (size > 4.5) {
+          toast.error('File size is too large!')
+          setSaving(false)
+          return
+        }
+      }
       const data = await handleBannerImageUpload(
         imageFile as File,
         appState?.appState.token as string,
@@ -95,6 +105,14 @@ export const Footer = () => {
         appState?.appState.bannerImgUrl as Blob,
         'bannerImg',
       )
+      if (imageFile) {
+        const size = calculateFileSize(imageFile)
+        if (size > 4.5) {
+          toast.error('Image size is too large!')
+          setSaving(false)
+          return
+        }
+      }
       const data = await handleBannerImageUpload(
         imageFile as File,
         appState?.appState.token as string,

--- a/src/utils/calculateFileSize.ts
+++ b/src/utils/calculateFileSize.ts
@@ -1,0 +1,3 @@
+export function calculateFileSize(file: File) {
+  return file.size / (1024 * 1024) //returns file size in MB
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4147,6 +4147,11 @@ globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+goober@^2.1.10:
+  version "2.1.14"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.14.tgz#4a5c94fc34dc086a8e6035360ae1800005135acd"
+  integrity sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
@@ -5905,6 +5910,13 @@ react-easy-crop@^5.0.2:
   dependencies:
     normalize-wheel "^1.0.1"
     tslib "2.0.1"
+
+react-hot-toast@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/react-hot-toast/-/react-hot-toast-2.4.1.tgz#df04295eda8a7b12c4f968e54a61c8d36f4c0994"
+  integrity sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==
+  dependencies:
+    goober "^2.1.10"
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
Error message has been shown when user tries to save banner image with file size greater than 4.5MB limit. The error message is shown as a toast using react-hot-toast.

[LOOM](https://www.loom.com/share/b6a9dec62eea4134ae45977dacc1a22a?sid=4e103c8a-554f-4a2a-9e0c-614ea26fd37d)
