### PR TITLE
OUT-396  Null issue for hex background color on client home

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,7 +15,7 @@ model Setting {
   id              String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   bannerImageId   String?  @unique @db.Uuid
   bannerImage     Media?   @relation(fields: [bannerImageId], references: [id], onDelete: SetNull)
-  backgroundColor String?
+  backgroundColor String   @default("#ffffff")
   displayTasks    Boolean  @default(false)
   content         String?
   notifications   Json?
@@ -23,18 +23,18 @@ model Setting {
   createdById     String   @db.Uuid
   createdAt       DateTime @default(now()) @db.Timestamptz()
   updatedAt       DateTime @updatedAt @ignore @db.Timestamptz()
- 
+
   @@index([bannerImageId], name: "bannerImageId")
 }
 
 model Media {
-  id              String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  url             String
-  filename        String
-  contentType     String
-  size            Int
-  createdById     String   @db.Uuid
-  createdAt       DateTime @default(now()) @db.Timestamptz()
-  updatedAt       DateTime @updatedAt @ignore @db.Timestamptz()
-  setting         Setting?
+  id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  url         String
+  filename    String
+  contentType String
+  size        Int
+  createdById String   @db.Uuid
+  createdAt   DateTime @default(now()) @db.Timestamptz()
+  updatedAt   DateTime @updatedAt @ignore @db.Timestamptz()
+  setting     Setting?
 }

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -64,7 +64,7 @@ export const Footer = () => {
         appState?.appState.token as string,
       )
       payload = {
-        backgroundColor: appState?.appState.editorColor,
+        backgroundColor: appState?.appState.editorColor || '#ffffff',
         content: content,
         bannerImageId: data?.id,
         token: appState?.appState.token,
@@ -77,7 +77,7 @@ export const Footer = () => {
 
     if (!appState?.appState.bannerImgUrl) {
       payload = {
-        backgroundColor: appState?.appState?.editorColor,
+        backgroundColor: appState?.appState.editorColor || '#ffffff',
         content: content,
         token: appState?.appState.token,
         bannerImageId: null,
@@ -118,7 +118,7 @@ export const Footer = () => {
         appState?.appState.token as string,
       )
       payload = {
-        backgroundColor: appState?.appState.editorColor,
+        backgroundColor: appState?.appState.editorColor || '#ffffff',
         content: content,
         bannerImageId: data?.id,
         token: appState?.appState.token,
@@ -127,7 +127,7 @@ export const Footer = () => {
       }
     } else {
       payload = {
-        backgroundColor: appState?.appState?.editorColor,
+        backgroundColor: appState?.appState.editorColor || '#ffffff',
         content: content,
         token: appState?.appState.token,
         displayTasks: appState?.appState.displayTasks,


### PR DESCRIPTION
### Task/Ticket

[Null issue for hex background color on client home](https://linear.app/copilotplatforms/issue/OUT-396/null-issue-for-hex-background-color-on-client-home)

#### The main changes are

- [x] Adds default value as `#ffffff` in both schema and payload from UI
