### PR TITLE
OUT-407 Error in Client Home when content is null

### DIFF
--- a/src/app/client-preview/page.tsx
+++ b/src/app/client-preview/page.tsx
@@ -83,7 +83,10 @@ export default async function ClientPreviewPage({
   const company = await getCompany(_client.companyId, token)
 
   if (defaultSetting) {
-    settings = defaultSetting
+    settings = {
+      ...defaultSetting,
+      content: defaultSetting?.content || defaultState,
+    }
   }
 
   const template = Handlebars?.compile(settings?.content)

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -39,7 +39,7 @@ export const Footer = () => {
   const handleSave = async () => {
     setSaving(true)
     //get editor content
-    const content = appState?.appState.editor?.getHTML()
+    const content = appState?.appState.editor?.getHTML() || ''
 
     let payload = {}
     const bgColor = appState?.appState.editorColor || '#ffffff'


### PR DESCRIPTION
### Task/Ticket

[Error in Client Home when content is null](https://linear.app/copilotplatforms/issue/OUT-407/error-in-client-home-when-content-is-null)

#### The main changes are

- [x] Handles null cases in the client preview
- [x] Uses `or ||` operator in case content is null while saving
