### PR TITLE
OUT-445 The font for the client home page in the client portal does not reflect the font selected in the IU's customization setting

### DIFF
--- a/src/app/client-preview/page.tsx
+++ b/src/app/client-preview/page.tsx
@@ -167,6 +167,7 @@ export default async function ClientPreviewPage({
             content={htmlContent}
             settings={settings}
             token={searchParams.token}
+            font={workspace.font}
           />
         </div>
       </div>

--- a/src/app/client-preview/page.tsx
+++ b/src/app/client-preview/page.tsx
@@ -74,11 +74,15 @@ export default async function ClientPreviewPage({
     displayTasks: false,
   }
 
-  const [defaultSetting, allCustomFields, _client] = await Promise.all([
-    getSettings(token),
-    getCustomFields(searchParams.token),
-    getClient(clientId, token),
-  ])
+  const copilotClient = new CopilotAPI(token)
+
+  const [defaultSetting, allCustomFields, _client, workspace] =
+    await Promise.all([
+      getSettings(token),
+      getCustomFields(searchParams.token),
+      getClient(clientId, token),
+      copilotClient.getWorkspaceInfo(),
+    ])
 
   const company = await getCompany(_client.companyId, token)
 
@@ -123,40 +127,49 @@ export default async function ClientPreviewPage({
     : settings?.bannerImage?.url
 
   return (
-    <div
-      className={`overflow-y-auto overflow-x-hidden max-h-screen w-full`}
-      style={{
-        background: `${settings.backgroundColor}`,
-      }}
-    >
-      {bannerImgUrl && (
-        <Image
-          className='w-full'
-          src={bannerImgUrl}
-          alt='banner image'
-          width={0}
-          height={0}
-          sizes='100vw'
-          style={{
-            width: '100%',
-            height: '25vh',
-            objectFit: 'cover',
-          }}
+    <>
+      <head>
+        <link
+          href={`https://fonts.googleapis.com/css2?family=${workspace.font}&display=swap`}
+          rel='stylesheet'
         />
-      )}
+      </head>
       <div
-        className='px-14 py-350 max-w-xl'
+        className={`overflow-y-auto overflow-x-hidden max-h-screen w-full`}
         style={{
+          fontFamily: workspace.font.replaceAll('+', ' '),
           background: `${settings.backgroundColor}`,
-          margin: '0 auto',
         }}
       >
-        <ClientPreview
-          content={htmlContent}
-          settings={settings}
-          token={searchParams.token}
-        />
+        {bannerImgUrl && (
+          <Image
+            className='w-full'
+            src={bannerImgUrl}
+            alt='banner image'
+            width={0}
+            height={0}
+            sizes='100vw'
+            style={{
+              width: '100%',
+              height: '25vh',
+              objectFit: 'cover',
+            }}
+          />
+        )}
+        <div
+          className='px-14 py-350 max-w-xl'
+          style={{
+            background: `${settings.backgroundColor}`,
+            margin: '0 auto',
+          }}
+        >
+          <ClientPreview
+            content={htmlContent}
+            settings={settings}
+            token={searchParams.token}
+          />
+        </div>
       </div>
-    </div>
+    </>
   )
 }

--- a/src/app/components/ClientPreview.tsx
+++ b/src/app/components/ClientPreview.tsx
@@ -44,10 +44,12 @@ const ClientPreview = ({
   content,
   settings,
   token,
+  font,
 }: {
   content: string
   settings: ISettings
   token: string
+  font: string
 }) => {
   /**
    * Importing all the editor related imports and settings up this editor
@@ -151,8 +153,9 @@ const ClientPreview = ({
         appState?.toggleDisplayTasks()
       }
       appState?.setSettings(settings || _settings)
+      appState?.setFont(font)
     }
-  }, [editor, content, settings])
+  }, [editor, content, settings, font])
 
   useEffect(() => {
     if (editor) {

--- a/src/app/components/EditorInterface.tsx
+++ b/src/app/components/EditorInterface.tsx
@@ -61,9 +61,10 @@ import BubbleEmbedInput from '@/components/tiptap/iframe/IFrameInput'
 interface IEditorInterface {
   settings: ISettings | null
   token: string
+  font: string
 }
 
-const EditorInterface = ({ settings, token }: IEditorInterface) => {
+const EditorInterface = ({ settings, token, font }: IEditorInterface) => {
   const appState = useAppState()
 
   const initialEditorContent = 'Type "/" for commands'
@@ -288,10 +289,11 @@ const EditorInterface = ({ settings, token }: IEditorInterface) => {
             : _settings,
         )
         appState?.setToken(token)
+        appState?.setFont(font)
       }
       appState?.setLoading(false)
     })()
-  }, [settings, token])
+  }, [settings, token, font])
 
   useEffect(() => {
     if (!appState?.appState.settings) return

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -174,7 +174,12 @@ export const Footer = () => {
         !appState?.appState.readOnly
       }
     >
-      <div className='w-full flex flex-row justify-end gap-6 py-4 px-6 fixed bottom-0 bg-white border-t border-slate-300'>
+      <div
+        className='w-full flex flex-row justify-end gap-6 py-4 px-6 fixed bottom-0 bg-white border-t border-slate-300'
+        style={{
+          fontFamily: appState?.appState.font.replaceAll('+', ' '),
+        }}
+      >
         <button
           className='py-1 px-3 text-new-dark rounded text-[13px] rounded bg-white border border-slate-300'
           onClick={handleCancel}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -72,7 +72,11 @@ export default async function Page({
       <div style={{ fontFamily: workspace.font.replaceAll('+', ' ') }}>
         <div className='flex flex-row'>
           <div className='relative w-full'>
-            <EditorInterface settings={settings} token={token} />
+            <EditorInterface
+              settings={settings}
+              token={token}
+              font={workspace.font}
+            />
           </div>
           <div
             className='border-1 border-l border-slate-300 xl:hidden'

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -61,17 +61,15 @@ export default async function Page({
     getCustomFields(token),
   ])
 
-  const font = workspace.font?.replaceAll(' ', '+')
-
   return (
     <>
       <head>
         <link
-          href={`https://fonts.googleapis.com/css2?family=${font}&display=swap`}
+          href={`https://fonts.googleapis.com/css2?family=${workspace.font}&display=swap`}
           rel='stylesheet'
         />
       </head>
-      <div style={{ fontFamily: workspace.font }}>
+      <div style={{ fontFamily: workspace.font.replaceAll('+', ' ') }}>
         <div className='flex flex-row'>
           <div className='relative w-full'>
             <EditorInterface settings={settings} token={token} />

--- a/src/components/NotificationsModal/ModalCheckbox.tsx
+++ b/src/components/NotificationsModal/ModalCheckbox.tsx
@@ -13,6 +13,7 @@ import { useSortable } from '@dnd-kit/sortable'
 import { Box, Checkbox, Typography } from '@mui/material'
 import { Dispatch, SetStateAction, useState } from 'react'
 import { CSS } from '@dnd-kit/utilities'
+import { useAppState } from '@/hooks/useAppState'
 
 const notificationIcons: { [_key in NotificationOption]: SVGIcon } = {
   billing: BillingIcon,
@@ -33,6 +34,7 @@ const ModalCheckbox = ({
   setFormState,
   setShowError,
 }: ModalCheckboxProps) => {
+  const appState = useAppState()
   const Icon: SVGIcon = notificationIcons[identifier]
 
   const { attributes, listeners, setNodeRef, transform, transition } =
@@ -91,6 +93,7 @@ const ModalCheckbox = ({
             variant='body1'
             id='modal-modal-description'
             className='flex items-center font-medium mt-4 '
+            sx={{ fontFamily: appState?.appState.font.replaceAll('+', ' ') }}
           >
             {capitalizeFirstLetter(identifier as string)}
           </Typography>

--- a/src/components/NotificationsModal/index.tsx
+++ b/src/components/NotificationsModal/index.tsx
@@ -119,10 +119,7 @@ const NotificationsModal = ({ settings }: NotificationsModalProps) => {
       }}
       sx={{ zIndex: 999999999 }} //highest in the app
     >
-      <div
-        className='absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-[80vw] max-w-[720px] bg-white rounded-md shadow-lg outline-none font-medium'
-        style={{ fontFamily: appState?.appState.font.replaceAll('+', ' ') }}
-      >
+      <div className='absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-[80vw] max-w-[720px] bg-white rounded-md shadow-lg outline-none font-medium'>
         <Fade in={showError}>
           <Box
             sx={{
@@ -134,7 +131,11 @@ const NotificationsModal = ({ settings }: NotificationsModalProps) => {
             <Alert severity='error'>At least 1 app should be selected.</Alert>
           </Box>
         </Fade>
-        <Typography variant='h6' className='px-6 pt-6 pb-4 font-medium'>
+        <Typography
+          variant='h6'
+          className='px-6 pt-6 pb-4 font-medium'
+          sx={{ fontFamily: appState?.appState.font.replaceAll('+', ' ') }}
+        >
           Customize notifications widget
         </Typography>
         <hr />
@@ -145,10 +146,22 @@ const NotificationsModal = ({ settings }: NotificationsModalProps) => {
               color: '#6B6F76',
             }}
           >
-            <Typography variant='body2' id='modal-modal-description'>
+            <Typography
+              variant='body2'
+              id='modal-modal-description'
+              sx={{
+                fontFamily: appState?.appState.font.replaceAll('+', ' '),
+              }}
+            >
               App name
             </Typography>
-            <Typography variant='body2' id='modal-modal-description'>
+            <Typography
+              variant='body2'
+              id='modal-modal-description'
+              sx={{
+                fontFamily: appState?.appState.font.replaceAll('+', ' '),
+              }}
+            >
               Enable
             </Typography>
           </Box>
@@ -175,7 +188,12 @@ const NotificationsModal = ({ settings }: NotificationsModalProps) => {
           </DndContext>
         </div>
         <hr />
-        <div className='flex justify-end gap-4 py-6 px-8'>
+        <div
+          className='flex justify-end gap-4 py-6 px-8'
+          style={{
+            fontFamily: appState?.appState.font.replaceAll('+', ' '),
+          }}
+        >
           <button
             className='py-1 px-3 text-new-dark text-[13px] rounded bg-white border border-slate-300'
             onClick={handleCancel}

--- a/src/components/NotificationsModal/index.tsx
+++ b/src/components/NotificationsModal/index.tsx
@@ -119,7 +119,10 @@ const NotificationsModal = ({ settings }: NotificationsModalProps) => {
       }}
       sx={{ zIndex: 999999999 }} //highest in the app
     >
-      <div className='absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-[80vw] max-w-[720px] bg-white rounded-md shadow-lg outline-none font-medium'>
+      <div
+        className='absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-[80vw] max-w-[720px] bg-white rounded-md shadow-lg outline-none font-medium'
+        style={{ fontFamily: appState?.appState.font.replaceAll('+', ' ') }}
+      >
         <Fade in={showError}>
           <Box
             sx={{

--- a/src/components/tiptap/notificationWidget/NotificationWidget.tsx
+++ b/src/components/tiptap/notificationWidget/NotificationWidget.tsx
@@ -61,6 +61,7 @@ export const NotificationWidget = () => {
           style={{
             position: 'relative',
             cursor: appState?.appState.readOnly ? 'auto' : 'pointer',
+            fontFamily: appState?.appState.font.replaceAll('+', ' '),
           }}
         >
           <Typography variant='h2' datatype='draggable-item'>

--- a/src/components/tiptap/notificationWidget/NotificationWidget.tsx
+++ b/src/components/tiptap/notificationWidget/NotificationWidget.tsx
@@ -50,6 +50,8 @@ export const NotificationWidget = () => {
     return Number(taskCount) > 0
   }, [appState?.appState.displayTasks, appState?.appState.readOnly, taskCount])
 
+  console.log('from notif widget', appState?.appState.font.replaceAll('+', ' '))
+
   return (
     <NodeViewWrapper data-drag-handle contentEditable={false}>
       {show && (
@@ -60,11 +62,15 @@ export const NotificationWidget = () => {
           onMouseOut={() => setHovered(false)}
           style={{
             position: 'relative',
-            cursor: appState?.appState.readOnly ? 'auto' : 'pointer',
-            fontFamily: appState?.appState.font.replaceAll('+', ' '),
           }}
         >
-          <Typography variant='h2' datatype='draggable-item'>
+          <Typography
+            variant='h2'
+            datatype='draggable-item'
+            sx={{
+              fontFamily: appState?.appState.font.replaceAll('+', ' '),
+            }}
+          >
             You have {taskCount} task
             {!appState?.appState?.readOnly || Number(taskCount) > 1
               ? 's'
@@ -163,6 +169,7 @@ const NotificationComponent = ({
   display?: boolean
 }) => {
   const pathname = usePathname()
+  const appState = useAppState()
 
   return (
     <Stack
@@ -171,12 +178,26 @@ const NotificationComponent = ({
       display={display ? 'flex' : 'none'}
       alignItems='center'
     >
-      <Typography variant='body1'>{name}</Typography>
+      <Typography
+        variant='body1'
+        sx={{
+          fontFamily: appState?.appState.font.replaceAll('+', ' '),
+        }}
+      >
+        {name}
+      </Typography>
       <RedirectButton
         route={route}
         execute={pathname.includes('client-preview')}
       >
-        <Typography variant='body1'>Go to {route}</Typography>
+        <Typography
+          variant='body1'
+          sx={{
+            fontFamily: appState?.appState.font.replaceAll('+', ' '),
+          }}
+        >
+          Go to {route}
+        </Typography>
       </RedirectButton>
     </Stack>
   )

--- a/src/components/tiptap/notificationWidget/NotificationWidget.tsx
+++ b/src/components/tiptap/notificationWidget/NotificationWidget.tsx
@@ -50,8 +50,6 @@ export const NotificationWidget = () => {
     return Number(taskCount) > 0
   }, [appState?.appState.displayTasks, appState?.appState.readOnly, taskCount])
 
-  console.log('from notif widget', appState?.appState.font.replaceAll('+', ' '))
-
   return (
     <NodeViewWrapper data-drag-handle contentEditable={false}>
       {show && (

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -31,6 +31,7 @@ export interface IAppState {
   token: string
   notifications: INotification | undefined
   showEmbedInput: boolean
+  font: string
 }
 
 export interface IAppContext {
@@ -54,6 +55,7 @@ export interface IAppContext {
   setToken: (token: string) => void
   setNotification: (notification: INotification) => void
   setShowEmbedInput: (v: boolean) => void
+  setFont: (font: string) => void
 }
 
 interface IAppCoreProvider {
@@ -83,6 +85,7 @@ export const AppContextProvider: FC<IAppCoreProvider> = ({ children }) => {
     showNotificationsModal: false,
     notifications: undefined,
     showEmbedInput: false,
+    font: 'Inter', //default font
   })
 
   const toggleShowLinkInput = (v: boolean) => {
@@ -167,6 +170,8 @@ export const AppContextProvider: FC<IAppCoreProvider> = ({ children }) => {
     setState((prev) => ({ ...prev, showEmbedInput: v }))
   }
 
+  const setFont = (font: string) => setState((prev) => ({ ...prev, font }))
+
   return (
     <AppContext.Provider
       value={{
@@ -190,6 +195,7 @@ export const AppContextProvider: FC<IAppCoreProvider> = ({ children }) => {
         setToken,
         setNotification,
         setShowEmbedInput,
+        setFont,
       }}
     >
       <AppDataProvider>{children}</AppDataProvider>


### PR DESCRIPTION
### Task/Ticket

[The font for the client home page in the client portal does not reflect the font selected in the IU's customization setting](https://linear.app/copilotplatforms/issue/OUT-445/the-font-for-the-client-home-page-in-the-client-portal-does-not)

#### The main changes are

- [x] Adds dynamic font by fetching `workspace` details in the `client-preview` page
- [x] Removes `+` from fonts with multiple words while initializing the font in the `style`
- [x] Adds dynamic font style to notification widget and modal
