### PR TITLE
OUT-789 | Certain CUs Missing from Preview Mode dropdown in Client Home

### DIFF
--- a/src/utils/copilotApiUtils.ts
+++ b/src/utils/copilotApiUtils.ts
@@ -53,7 +53,9 @@ export class CopilotAPI {
   }
 
   async getClients() {
-    return ClientsResponseSchema.parse(await this.copilot.listClients({}))
+    return ClientsResponseSchema.parse(
+      await this.copilot.listClients({ limit: 5000 }),
+    )
   }
 
   async getCompany(companyId: string): Promise<CompanyResponse> {


### PR DESCRIPTION
### Task/Ticket

[OUT-789 | Certain CUs Missing from Preview Mode dropdown in Client Home](https://linear.app/copilotplatforms/issue/OUT-789/certain-cus-missing-from-preview-mode-dropdown-in-client-home)

#### The main changes are

- [x] Increased limit for clients page to 5k.