### PR TITLE
fix(OUT-1284): marketplace app support object for customField value

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -32,7 +32,11 @@ export const ClientResponseSchema = z.object({
   customFields: z
     .record(
       z.string(),
-      z.union([z.string().nullable(), z.array(z.string()).nullable()]),
+      z.union([
+        z.string().nullable(),
+        z.array(z.string()).nullable(),
+        z.object({}).nullable(),
+      ]),
     )
     .nullable(),
   avatarImageUrl: z.string().nullable(),


### PR DESCRIPTION
### Task/Ticket

[IU is receiving an error for Client Home app]([Task Link](https://linear.app/copilotplatforms/issue/OUT-1284/iu-is-receiving-an-error-for-client-home-app))

#### Root Cause
We updated how custom fields value can be returned. Previously it was either a string or array and now it can also be an object. This was causing a zodSchema defined in client home to fail and caused the page to crash.

#### The main changes are

Update the union in the zod schema to allow objects along side string and array.

I didn't spent too much time debugging this. Im going to open a sub-ticket for Outside to make this more robust. The whole app should not crash in cases like this.

