### PR TITLE
fix(POR-12904): client home not loading for clients without custom fields

### DIFF
--- a/src/app/client-preview/page.tsx
+++ b/src/app/client-preview/page.tsx
@@ -122,9 +122,11 @@ export default async function ClientPreviewPage({
     }
   }
 
-  for (const key of Object.keys(customFields)) {
-    if (customFields[key]?.fullAddress) {
-      customFields[key] = customFields[key].fullAddress
+  if (customFields) {
+    for (const key of Object.keys(customFields)) {
+      if (customFields[key]?.fullAddress) {
+        customFields[key] = customFields[key].fullAddress
+      }
     }
   }
 


### PR DESCRIPTION
### Task/Ticket

[No client with token client home error]([Task Link](https://linear.app/copilotplatforms/issue/POR-12904/no-client-with-token-client-home-error))

#### The main changes are

Check for customFields existing before iterating over them.


#### Root Cause
- this was a regression caused by a recent fix to show fullAddress in client home.
- we only tested when custom fields was present and not when it was not set.
