### PR TITLE
OUT-1436 | Use `clientId` from token payload and deprecate clientId search param

### DIFF
--- a/src/app/client-preview/page.tsx
+++ b/src/app/client-preview/page.tsx
@@ -49,7 +49,7 @@ async function getCustomFields(token: string) {
 export default async function ClientPreviewPage({
   searchParams,
 }: {
-  searchParams: { token: string; clientId: string }
+  searchParams: { token: string }
 }) {
   const tokenParsed = z.string().safeParse(searchParams.token)
   if (!tokenParsed.success) {
@@ -66,7 +66,7 @@ export default async function ClientPreviewPage({
     return <NoPreviewSupport />
   }
 
-  const clientId = z.string().uuid().parse(searchParams.clientId)
+  const clientId = z.string().uuid().parse(tokenPayload.clientId)
 
   let settings: ISettings = {
     content: defaultState,


### PR DESCRIPTION
## Testing:

![image](https://github.com/user-attachments/assets/e0cd74e7-fead-4737-95f6-5ce0a2ac0548)