### PR TITLE
OUT-1853: TypeError: t.appState.font.replaceAll is not a function

### DIFF
--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -4,6 +4,7 @@ import { When } from '@/components/hoc/When'
 import { useAppState } from '@/hooks/useAppState'
 import { calculateFileSize } from '@/utils/calculateFileSize'
 import { defaultBannerImagePath } from '@/utils/constants'
+import { getFont } from '@/utils/font'
 import { handleBannerImageUpload } from '@/utils/handleBannerImageUpload'
 import { ImagePickerUtils } from '@/utils/imagePickerUtils'
 import { useEffect, useState } from 'react'
@@ -177,7 +178,7 @@ export const Footer = () => {
       <div
         className='w-full flex flex-row justify-end gap-6 py-4 px-6 fixed bottom-0 bg-white border-t border-slate-300'
         style={{
-          fontFamily: appState?.appState.font.replaceAll('+', ' '),
+          fontFamily: getFont(appState),
         }}
       >
         <button

--- a/src/components/NotificationsModal/ModalCheckbox.tsx
+++ b/src/components/NotificationsModal/ModalCheckbox.tsx
@@ -10,6 +10,7 @@ import {
   TasksIcon,
 } from '@/icons'
 import { Notification, NotificationOption } from '@/types/notifications'
+import { getFont } from '@/utils/font'
 import { capitalizeFirstLetter } from '@/utils/string'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
@@ -101,7 +102,7 @@ const ModalCheckbox = ({
             variant='body1'
             id='modal-modal-description'
             className='flex items-center font-medium mt-4 '
-            sx={{ fontFamily: appState?.appState.font.replaceAll('+', ' ') }}
+            sx={{ fontFamily: getFont(appState) }}
           >
             {capitalizeFirstLetter(identifier as string)}
           </Typography>

--- a/src/components/NotificationsModal/index.tsx
+++ b/src/components/NotificationsModal/index.tsx
@@ -25,6 +25,7 @@ import {
 import { fetcher } from '@/utils/fetcher'
 import useSWR from 'swr'
 import { useTasksAppId } from '@/hooks/useTasksAppId'
+import { getFont } from '@/utils/font'
 
 interface NotificationsModalProps {
   settings: ISettings | null
@@ -139,7 +140,7 @@ const NotificationsModal = ({ settings }: NotificationsModalProps) => {
         <Typography
           variant='h6'
           className='px-6 pt-6 pb-4 font-medium'
-          sx={{ fontFamily: appState?.appState.font.replaceAll('+', ' ') }}
+          sx={{ fontFamily: getFont(appState) }}
         >
           Customize notifications widget
         </Typography>
@@ -155,7 +156,7 @@ const NotificationsModal = ({ settings }: NotificationsModalProps) => {
               variant='body2'
               id='modal-modal-description'
               sx={{
-                fontFamily: appState?.appState.font.replaceAll('+', ' '),
+                fontFamily: getFont(appState),
               }}
             >
               App name
@@ -164,7 +165,7 @@ const NotificationsModal = ({ settings }: NotificationsModalProps) => {
               variant='body2'
               id='modal-modal-description'
               sx={{
-                fontFamily: appState?.appState.font.replaceAll('+', ' '),
+                fontFamily: getFont(appState),
               }}
             >
               Enable
@@ -197,7 +198,7 @@ const NotificationsModal = ({ settings }: NotificationsModalProps) => {
         <div
           className='flex justify-end gap-4 py-6 px-8'
           style={{
-            fontFamily: appState?.appState.font.replaceAll('+', ' '),
+            fontFamily: getFont(appState),
           }}
         >
           <button

--- a/src/components/tiptap/notificationWidget/NotificationWidget.tsx
+++ b/src/components/tiptap/notificationWidget/NotificationWidget.tsx
@@ -3,6 +3,7 @@ import { useAppData } from '@/hooks/useAppData'
 import { useAppState } from '@/hooks/useAppState'
 import { useTasksAppId } from '@/hooks/useTasksAppId'
 import { PortalRoutes } from '@/types/copilotPortal'
+import { getFont } from '@/utils/font'
 import { DragIndicatorRounded } from '@mui/icons-material'
 import { Box, Stack, Typography } from '@mui/material'
 import { NodeViewWrapper } from '@tiptap/react'
@@ -69,7 +70,7 @@ export const NotificationWidget = () => {
             variant='h2'
             datatype='draggable-item'
             sx={{
-              fontFamily: appState?.appState.font.replaceAll('+', ' '),
+              fontFamily: getFont(appState),
             }}
           >
             You have {actionCount} action
@@ -202,7 +203,7 @@ const NotificationComponent = ({
       <Typography
         variant='body1'
         sx={{
-          fontFamily: appState?.appState.font.replaceAll('+', ' '),
+          fontFamily: getFont(appState),
         }}
       >
         {name}
@@ -215,7 +216,7 @@ const NotificationComponent = ({
         <Typography
           variant='body1'
           sx={{
-            fontFamily: appState?.appState.font.replaceAll('+', ' '),
+            fontFamily: getFont(appState),
           }}
         >
           Go to {route}

--- a/src/utils/font.ts
+++ b/src/utils/font.ts
@@ -1,4 +1,4 @@
 import { IAppContext } from '@/context'
 
 export const getFont = (appState?: IAppContext | null) =>
-  appState?.appState?.font?.replaceAll('+', ' ') || 'sans'
+  appState?.appState?.font?.replaceAll('+', ' ') || 'sans-serif' // Inter is a sans-serif font so this is a sane fallback

--- a/src/utils/font.ts
+++ b/src/utils/font.ts
@@ -1,0 +1,4 @@
+import { IAppContext } from '@/context'
+
+export const getFont = (appState?: IAppContext | null) =>
+  appState?.appState?.font?.replaceAll('+', ' ') || 'sans'


### PR DESCRIPTION
## Fix:
 - [x] `fontFamily` was being set as `'undefined'`, causing the browser to treat it and search for it as a font name. Added default fallback `sans-serif`