### PR TITLE
fix: handle internal user preview mode before validating clientId/companyId

### DIFF
--- a/src/app/client-preview/page.tsx
+++ b/src/app/client-preview/page.tsx
@@ -60,12 +60,16 @@ export default async function ClientPreviewPage({
   const token = tokenParsed.data
   const copilotClient = new CopilotAPI(token)
   const tokenPayload = await copilotClient.getTokenPayload()
-  if (!tokenPayload || !tokenPayload.clientId || !tokenPayload.companyId) {
+  if (!tokenPayload) {
     console.info('Failing token payload', tokenPayload)
     throw new Error('Failed to parse token payload')
   }
   if (getPreviewMode(tokenPayload)) {
     return <NoPreviewSupport />
+  }
+  if (!tokenPayload.clientId || !tokenPayload.companyId) {
+    console.info('Missing clientId or companyId in token payload', tokenPayload)
+    throw new Error('Failed to parse token payload')
   }
 
   const clientId = z.string().uuid().parse(tokenPayload.clientId)


### PR DESCRIPTION
## Summary
Fixed logic that checks clientId/companyId requirements when rendering the client preview page. When internalUserId is provided, the app now correctly shows the 'CRM preview is not available' message instead of throwing an error.

## Changes
- Reordered validation logic in src/app/client-preview/page.tsx
- Check for token payload existence first  
- Call getPreviewMode() to handle internal users before validating clientId/companyId
- Only validate clientId/companyId after determining it's not a preview mode scenario

## Test plan
- Test with token containing only internalUserId - should show 'CRM preview is not available'
- Test with token containing clientId and companyId - should render normally
- Test with malformed token - should show appropriate error