### PR TITLE
OUT-2153 | Suppress errors propagating from iframes in Client Home editor

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,8 @@
+import { Footer } from '@/app/components/Footer'
 import { AppContextProvider } from '@/context'
-import './globals.css'
 import type { Metadata } from 'next'
-import { Footer } from './components/Footer'
+import Script from 'next/script'
+import './globals.css'
 
 export const metadata: Metadata = {
   title: 'Client Home App',
@@ -15,6 +16,27 @@ export default async function RootLayout({
 }) {
   return (
     <html lang='en'>
+      <head>
+        {/* Make sure the error suppression script runs BEFORE sentry can init */}
+        <Script id='suppress-iframe-errors' strategy='beforeInteractive'>
+          {`(function(){
+            window.addEventListener('error', function(ev){
+              var t = ev.target;
+              if (t && t.tagName === 'IFRAME') {
+                ev.stopImmediatePropagation();
+                console.log('[iframe load error]', t.src);
+                return;
+              }
+              if (ev instanceof ErrorEvent && ev.message === 'Script error.') {
+                ev.stopImmediatePropagation();
+                console.log('[iframe script error]', ev.filename);
+                return;
+              }
+            }, true);
+          })();`}
+        </Script>
+      </head>
+
       <body>
         <AppContextProvider>
           {children}

--- a/src/components/tiptap/iframe/EmbedComponent.tsx
+++ b/src/components/tiptap/iframe/EmbedComponent.tsx
@@ -66,6 +66,10 @@ export const EmbedComponent = (props: any) => {
           src={extractIframeSrc(props.node.attrs.src)}
           width='100%'
           height='100%'
+          onError={(e) => {
+            e.stopPropagation()
+            console.log('[iframe error]:', e)
+          }}
         />
       </div>
       {!pathname.includes('client-preview') && !appState?.appState.readOnly && (


### PR DESCRIPTION
## Changes:
- [x] Implemented an `onError` handler to stop loading errors from iframes from propagating
- [x] Implemented a global error handler that doesn't let rest of errors (e.g. runtime errors) from iframes to pass to Client Home's Sentry.