### PR TITLE
OUT-2147 | Bump CI node-version to 20

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
           cache-dependency-path: './yarn.lock'
 


### PR DESCRIPTION
## Changes:
- Bump CI job node-version from 18 to 20