### PR TITLE
OUT-2269 | Client Home app: Save Changes Bar shows up once I install "Client home" app

### DIFF
--- a/src/app/components/EditorInterface.tsx
+++ b/src/app/components/EditorInterface.tsx
@@ -214,7 +214,7 @@ const EditorInterface = ({
       if (
         appState?.appState.originalTemplate?.replace(/\s/g, '') !==
           prepareCustomLabel(
-            defaultState.replaceAll(/\s/g, ''),
+            defaultState.replaceAll(' ', ''),
             appState?.appState?.customLabels,
           ) ||
         appState?.appState.bannerImgUrl !== defaultBannerImagePath ||

--- a/src/app/components/EditorInterface.tsx
+++ b/src/app/components/EditorInterface.tsx
@@ -214,7 +214,7 @@ const EditorInterface = ({
       if (
         appState?.appState.originalTemplate?.replace(/\s/g, '') !==
           prepareCustomLabel(
-            defaultState.replace(/\s/g, ''),
+            defaultState.replaceAll(/\s/g, ''),
             appState?.appState?.customLabels,
           ) ||
         appState?.appState.bannerImgUrl !== defaultBannerImagePath ||

--- a/src/app/components/EditorInterface.tsx
+++ b/src/app/components/EditorInterface.tsx
@@ -213,7 +213,10 @@ const EditorInterface = ({
     ) {
       if (
         appState?.appState.originalTemplate?.replace(/\s/g, '') !==
-          defaultState.replace(/\s/g, '') ||
+          prepareCustomLabel(
+            defaultState.replace(/\s/g, ''),
+            appState?.appState?.customLabels,
+          ) ||
         appState?.appState.bannerImgUrl !== defaultBannerImagePath ||
         (appState?.appState.settings.displayTasks !==
           appState?.appState.displayTasks &&

--- a/src/app/components/EditorInterface.tsx
+++ b/src/app/components/EditorInterface.tsx
@@ -232,7 +232,10 @@ const EditorInterface = ({
     ) {
       if (
         appState?.appState.originalTemplate?.toString() !==
-          appState?.appState.settings?.content?.toString() ||
+          prepareCustomLabel(
+            appState?.appState.settings?.content?.toString(),
+            appState?.appState?.customLabels,
+          ) ||
         appState?.appState.settings?.backgroundColor !==
           appState?.appState.editorColor ||
         (appState?.appState.settings.bannerImage?.url || '') !==


### PR DESCRIPTION
#### The main changes are

- [x] added prepareCustomLabel for dif comparison while triggering save changes.
- [x] applied prepareCustomLabel on defaultState while checking for changes diff. 
