### PR TITLE
OUT-2277 | Client home does not filter notifications based on active company

### DIFF
--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -4,6 +4,7 @@ import { notificationEvents } from '@/utils/notifications'
 import { errorHandler } from '@/utils/common'
 import httpStatus from 'http-status'
 import { ApiError } from '@/exceptions/ApiError'
+import { z } from 'zod'
 
 export async function GET(request: NextRequest) {
   try {
@@ -31,12 +32,21 @@ export async function GET(request: NextRequest) {
       tasks: taskCounts,
     }
 
-    notifications.forEach(({ event }) => {
-      if (event === notificationEvents.forms) {
+    notifications.forEach((notification) => {
+      const notificationCompanyId = z
+        .string()
+        .min(1)
+        // We use both fields for backwards compatibility
+        .parse(notification.recipientCompanyId || notification.companyId)
+      if (companyId !== notificationCompanyId) {
+        return
+      }
+
+      if (notification.event === notificationEvents.forms) {
         counts.forms += 1
-      } else if (event === notificationEvents.billing) {
+      } else if (notification.event === notificationEvents.billing) {
         counts.billing += 1
-      } else if (event === notificationEvents.contracts) {
+      } else if (notification.event === notificationEvents.contracts) {
         counts.contracts += 1
       }
     })

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -86,6 +86,8 @@ export type CustomFieldResponse = z.infer<typeof CustomFieldResponseSchema>
 export const NotificationsSchema = z.array(
   z.object({
     event: z.string(),
+    companyId: z.string().optional(),
+    recipientCompanyId: z.string().optional(),
   }),
 )
 export type Notifications = z.infer<typeof NotificationsSchema>


### PR DESCRIPTION
# Changes:

Apply notification filtering on basis of company ID (does not affect tasks count since we use Tasks Public API for this, which accounts for it)

## Testing Criteria:

I have a multi-company client with different number of notifications on each.

- Cats & Co:

<img width="282" height="425" alt="image" src="https://github.com/user-attachments/assets/e8020e06-a246-4d06-a0eb-aa70c9c45ecc" />

<img width="827" height="261" alt="image" src="https://github.com/user-attachments/assets/2a9e220c-496a-43ec-a5a7-0c66da1e1188" />

- Roj & Co.

<img width="313" height="259" alt="image" src="https://github.com/user-attachments/assets/7f54b2be-8f75-4ae3-a0bf-5361aece8924" />

<img width="803" height="347" alt="image" src="https://github.com/user-attachments/assets/6d6f00bb-b779-4ed7-9243-bb77ce0428aa" />
