### PR TITLE
OUT-2269 | Client Home app: Save Changes Bar shows up once I install "Client home" app

### DIFF
--- a/src/app/components/EditorInterface.tsx
+++ b/src/app/components/EditorInterface.tsx
@@ -215,7 +215,10 @@ const EditorInterface = ({
       appState?.appState.originalTemplate
     ) {
       if (
-        appState?.appState.originalTemplate?.replace(/\s/g, '') !==
+        replaceCustomLabelsWithPlaceholders(
+          appState?.appState.originalTemplate?.replace(/\s/g, ''),
+          appState?.appState?.customLabels,
+        ) !==
           replaceCustomLabelsWithPlaceholders(
             defaultState.replaceAll(' ', ''),
             appState?.appState?.customLabels,
@@ -237,7 +240,10 @@ const EditorInterface = ({
       appState?.appState.originalTemplate
     ) {
       if (
-        appState?.appState.originalTemplate?.toString() !==
+        replaceCustomLabelsWithPlaceholders(
+          appState?.appState.originalTemplate?.toString(),
+          appState?.appState?.customLabels,
+        ) !==
           replaceCustomLabelsWithPlaceholders(
             appState?.appState.settings?.content?.toString(),
             appState?.appState?.customLabels,


### PR DESCRIPTION
#### The main changes are

- [x] also replaced placeholders on original template and default state while checking diff. 
