### PR TITLE
fix: handle content can be undefined

### DIFF
--- a/src/utils/customLabels.ts
+++ b/src/utils/customLabels.ts
@@ -61,15 +61,15 @@ export const prepareCustomLabel = (
 }
 
 export const replaceCustomLabelsWithPlaceholders = (
-  content: string,
-  customLables?: CustomLabels,
+  content?: string,
+  customLabels?: CustomLabels,
 ) => {
-  if (!customLables) return content
+  if (!customLabels) return content
 
   // NOTE: Only hardcoded for client as per Client Home requirements. It's highly unlikely we will
   // get other patterns since these are customFields
-  return content.replaceAll(
-    `{{${customLables.individualTerm}.`,
+  return content?.replaceAll(
+    `{{${customLabels.individualTerm}.`,
     `{{__client__.`,
   )
 }


### PR DESCRIPTION
### Task/Ticket

handle undefined content to prevent error on replaceAll call

#### The main changes are

- [x] make content optional param and check for undefined before calling replaceAll.
