### PR TITLE
OUT-2315 | Client Home IU preview mode is not showing tags when a client is selected

### DIFF
--- a/src/app/components/EditorInterface.tsx
+++ b/src/app/components/EditorInterface.tsx
@@ -62,6 +62,7 @@ import { Delete } from '@mui/icons-material'
 import { Box } from '@mui/material'
 import Image from 'next/image'
 import { defaultState } from '../../../defaultState'
+import { preprocessTemplate } from '@/utils/string'
 
 interface IEditorInterface {
   settings: ISettings | null
@@ -185,7 +186,15 @@ const EditorInterface = ({
   useEffect(() => {
     if (appState?.appState.readOnly) {
       const template = Handlebars?.compile(
-        appState?.appState.originalTemplate || '',
+        preprocessTemplate(
+          prepareCustomLabel(
+            appState?.appState?.originalTemplate ?? '',
+            appState?.appState?.customLabels,
+            {
+              isClientMode: true,
+            },
+          ),
+        ),
       )
       const c = template(appData)
       setTimeout(() => {


### PR DESCRIPTION
#### The main changes are

- [x] applied preprocessTemplate util which removes the {{ and }} from template for rendering handlebars.

### Testing 

- [LOOM](https://www.loom.com/share/2d1d98c91afe4a3194f21cb8e52a0671)
