### PR TITLE
OUT-2328: triage: cannot read properties of undefined(reading 'contentType')

### DIFF
--- a/src/components/tiptap/floatingMenu/floatingMenuSuggestion.tsx
+++ b/src/components/tiptap/floatingMenu/floatingMenuSuggestion.tsx
@@ -5,6 +5,8 @@ import { FloatingMenu } from './FloatingMenu'
 import { TiptapEditorUtils } from '@/utils/tiptapEditorUtils'
 import { ImagePickerUtils } from '@/utils/imagePickerUtils'
 import { handleBannerImageUpload } from '@/utils/handleBannerImageUpload'
+import { calculateFileSize } from '@/utils/calculateFileSize'
+import toast from 'react-hot-toast'
 
 export const floatingMenuSuggestion = {
   items: ({ query }: any) => {
@@ -76,7 +78,16 @@ export const floatingMenuSuggestion = {
             'token',
           )
           if (file && token) {
+            // file size validation
+            const size = calculateFileSize(file)
+            if (size > 4.5) {
+              toast.error('File size is too large!')
+              return
+            }
+
             const data = await handleBannerImageUpload(file, token)
+            if (!data) toast.error('Something went wrong while uploading file')
+
             if (data.contentType === 'application/pdf') {
               tiptapEditorUtils.insertPdf(data.filename, data.url)
             } else {


### PR DESCRIPTION
### Changes

- [x] implement size validation before upload and error toast if validation fails
- [x] error toast if invoked variable is undefined

### Note:

- Upon checking the log, the upload process was returning 413 (file too large). Due to this the function handling the upload was not returning anything at all. That basically makes the invoking variable undefined.
